### PR TITLE
固定幅に調整

### DIFF
--- a/src/components/Dakoku.js
+++ b/src/components/Dakoku.js
@@ -18,7 +18,7 @@ export default class Dakoku extends React.Component {
             <div className="date-wrapper">
                 <div className="date">{year}/{month}/{day}</div>
 
-                <div className="time">{hh}:{mm}:{ss}</div>
+                <div className="time">{hh}:{mm}<span class="sec">:{ss}</span></div>
                 <ul>
                     {messages.map((m,index) => (
                         <li key={index}>{m}</li>

--- a/src/css/common.css
+++ b/src/css/common.css
@@ -47,7 +47,7 @@ body::-webkit-scrollbar{
 
 .side-nav{ 
     box-sizing: border-box;
-    width: 15%;
+    width: 250px;
     background: #215968;
     color:white;
 }
@@ -71,6 +71,7 @@ body::-webkit-scrollbar{
 
 .category-list-wrapper {
     box-sizing: border-box;
+    width: 250px;
 }
 .category-list {
     list-style: none;

--- a/src/css/dakoku.css
+++ b/src/css/dakoku.css
@@ -1,24 +1,30 @@
 
 .content.time {
     height: 100%;
+    width:calc(100vw - 600px);
     display: flex;
-    justify-content: center;
+    /*justify-content: center;*/
+    padding-left: 2em;
     align-items: center;
+    overflow: inherit;
+}
+
+.sec {
+    font-size: 0.5em;
 }
 
 .side-area.time{
-    width: 30%;
+    width: 450px;
     height: 100%;
     box-sizing: border-box;
     display: flex;
     justify-content: center;
     align-items: center;
-    padding-left:2em;
 }
 
 .date-wrapper {
     margin-left: 5%;
-    width: 90%;
+    width: 100%;
     height: 50%;
     text-align: left;
 }
@@ -31,6 +37,10 @@
 .date-wrapper .time {
     width: 100%;
     font-size: 7em;
+}
+
+.dakoku-buttun-wrapper ul {
+    padding-inline-start: 0;/*user agent stylesheet 打ち消し*/
 }
 
 .dakoku-buttun-wrapper li {


### PR DESCRIPTION
・打刻画面のコンテンツの幅を固定にしました。
　・画面幅を縮めた時、ブラウザの幅を超えたコンテンツは見えなくなります。
・可変レイアウト（画面幅を変えてもそれなりに表示）にするには他に色々変更が必要そうなので、
　発表用としてはいったん固定幅がよいかと思います。
・秒のフォントを小さくしました。